### PR TITLE
Use '-ExcutionPolicy Bypass' when running powershell.

### DIFF
--- a/toast.go
+++ b/toast.go
@@ -1,20 +1,21 @@
 package go_toast
 
 import (
-    "github.com/nu7hatch/gouuid"
-    "text/template"
-    "bytes"
-    "io/ioutil"
-    "os"
-    "os/exec"
-    "path/filepath"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
+
+	"github.com/nu7hatch/gouuid"
 )
 
 var toastTemplate *template.Template
 
 func init() {
-    toastTemplate = template.New("toast")
-    toastTemplate.Parse(`
+	toastTemplate = template.New("toast")
+	toastTemplate.Parse(`
 [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
 [Windows.UI.Notifications.ToastNotification, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
 [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null
@@ -50,47 +51,47 @@ $xml = New-Object Windows.Data.Xml.Dom.XmlDocument
 $xml.LoadXml($template)
 $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($APP_ID).Show($toast)
-    `);
+    `)
 }
 
 type Notification struct {
-    AppID string
-    Title string
-    Message string
-    Icon string
-    Actions []Action
+	AppID   string
+	Title   string
+	Message string
+	Icon    string
+	Actions []Action
 }
 
 type Action struct {
-    Type string
-    Label string
-    Arguments string
+	Type      string
+	Label     string
+	Arguments string
 }
 
 func (n *Notification) BuildXML() (string, error) {
-    var out bytes.Buffer
-    err := toastTemplate.Execute(&out, n)
-    if err != nil {
-        return "", err
-    }
-    return out.String(), nil
+	var out bytes.Buffer
+	err := toastTemplate.Execute(&out, n)
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
 }
 
 func (n *Notification) Push() error {
-    xml, _ := n.BuildXML()
-    return invokeTemporaryScript(xml)
+	xml, _ := n.BuildXML()
+	return invokeTemporaryScript(xml)
 }
 
-func invokeTemporaryScript(content string) (error) {
-    id, _ := uuid.NewV4()
-    file := filepath.Join(os.TempDir(), id.String() + ".ps1")
-    defer os.Remove(file)
-    err := ioutil.WriteFile(file, []byte(content), 0600)
-    if err != nil {
-        return err
-    }
-    if err = exec.Command("PowerShell", "-File", file).Run(); err != nil {
-        return err
-    }
-    return nil
+func invokeTemporaryScript(content string) error {
+	id, _ := uuid.NewV4()
+	file := filepath.Join(os.TempDir(), id.String()+".ps1")
+	defer os.Remove(file)
+	err := ioutil.WriteFile(file, []byte(content), 0600)
+	if err != nil {
+		return err
+	}
+	if err = exec.Command("PowerShell", "-ExecutionPolicy", "Bypass", "-File", file).Run(); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
A bit of format linting on the toast.go file, but primarily using the `-ExecutionPolicy Bypass` flag when calling the Powershell script so the user does have to have scripting explicitly permitted.

By the way, I'm not a Windows person and you saved my life with this nifty little notification tool. Thank you!